### PR TITLE
fix(statusline): fix Windows process filter and PS profile output noise

### DIFF
--- a/skills/antigravity-cli-statusline/scripts/fetch-local-quota.mjs
+++ b/skills/antigravity-cli-statusline/scripts/fetch-local-quota.mjs
@@ -33,9 +33,13 @@ function findServerCandidates() {
     const candidates = [];
     if (process.platform === 'win32') {
       try {
-        const psCmd = "powershell.exe -NoProfile -Command \"Get-CimInstance Win32_Process -Filter 'Name like ''%agy%'' or Name like ''%language_server%''' | Select-Object ProcessID, CommandLine | ConvertTo-Json -Compress\"";
+        const psCmd = "powershell.exe -NoProfile -Command \"Get-CimInstance Win32_Process -Filter 'Name like ''%antigravity%'' or Name like ''%agy%'' or Name like ''%language_server%''' | Select-Object ProcessID, CommandLine | ConvertTo-Json -Compress\"";
         output = execSync(psCmd, { encoding: 'utf8', windowsHide: true }).trim();
         if (output) {
+          const jsonStart = output.search(/\[|\{/);
+          if (jsonStart !== -1) {
+            output = output.slice(jsonStart);
+          }
           let processes = JSON.parse(output);
           if (!Array.isArray(processes)) {
             processes = [processes];
@@ -46,7 +50,7 @@ function findServerCandidates() {
             if (!pid) continue;
             
             const lower = cmdLine.toLowerCase();
-            const isCli = lower.includes('agy') && !lower.includes('statusline-quota');
+            const isCli = (lower.includes('antigravity') || lower.includes('agy')) && !lower.includes('statusline-quota');
             const isLang = lower.includes('language_server');
             if (!isCli && !isLang) continue;
             
@@ -67,7 +71,7 @@ function findServerCandidates() {
         const lines = output.split('\n');
         for (const line of lines) {
           const lower = line.toLowerCase();
-          const isCli = /\bagy(\s|$)/.test(lower);
+          const isCli = (/\bagy(\s|$)/.test(lower) || lower.includes('antigravity-cli')) && !lower.includes('statusline-quota');
           const isLang = lower.includes('language_server');
           if (!isCli && !isLang) continue;
           const parts = line.trim().split(/\s+/);

--- a/skills/antigravity-cli-statusline/scripts/test-counters.mjs
+++ b/skills/antigravity-cli-statusline/scripts/test-counters.mjs
@@ -586,7 +586,9 @@ async function main() {
         console.error(`    ❌ [${name}] 執行時發生例外:`, e);
         return false;
       } finally {
-        rmSync(home, { recursive: true, force: true });
+        try {
+          rmSync(home, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+        } catch (_) {}
       }
     };
 


### PR DESCRIPTION
Fixes #9

### Summary of Changes

1. **WMI Process Query & CLI Recognition**:
   - Updated `findServerCandidates()` in `fetch-local-quota.mjs` to include `'Name like ''%antigravity%'' or Name like ''%agy%'' or Name like ''%language_server%'''` in WMI `-Filter`.
   - Expanded process name recognition to `(lower.includes('antigravity') || lower.includes('agy')) && !lower.includes('statusline-quota')` to properly match `antigravity-cli.exe`.

2. **PowerShell Profile Output Filtering**:
   - Extracted JSON array/object starting from the first `[` or `{` in `output` before calling `JSON.parse()` to tolerate `$PROFILE` warnings (such as `Set-PSReadLineOption: ...`).

3. **Test Sandbox Reliability**:
   - Added retry logic (`maxRetries: 5, retryDelay: 100`) when deleting temporary sandboxes in `test-counters.mjs` on Windows.
